### PR TITLE
Appveyor or Github CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,51 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        build_configuration: [Release]
+        build_platform: [Any CPU]
+        build_boost_version: [1_88_0]
+        build_boost_version_dot: [1.88.0]
+        build_msvc_version_dot: [14.3, 14.2, 14.1]
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Setup Nuget.exe
+      uses: nuget/setup-nuget@v2
+
+    - name: restore input nuget packages
+      working-directory: builder\
+      run: |
+           nuget restore builder\packages.config -PackagesDirectory packages
+           nuget restore builderTest\packages.config -PackagesDirectory packages
+
+    - name: Setup to add MSBuild.exe to path
+      uses: microsoft/setup-msbuild@v2
+
+    - name: MSBuild of builder
+      working-directory: builder\
+      run: |
+           msbuild builder.sln /m /verbosity:minimal /t:restore /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+           msbuild builder.sln /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+      
+    - name: boost binary download created by https://github.com/teeks99/boost-release-windows
+      working-directory: .
+      run: |
+          Set-Location -Path 'D:\a'
+          New-Item -ItemType directory -Path D:\a\boostorg
+          Set-Location -Path 'D:\a\boostorg'
+          (New-Object System.Net.WebClient).DownloadFile("https://archives.boost.io/release/${{ matrix.build_boost_version_dot }}/binaries/boost_${{ matrix.build_boost_version }}-msvc-${{ matrix.build_msvc_version_dot }}-64.exe", "D:\a\boostorg\boost_${{ matrix.build_boost_version }}-msvc-${{ matrix.build_msvc_version_dot }}-64.exe")
+          (New-Object System.Net.WebClient).DownloadFile("https://archives.boost.io/release/${{ matrix.build_boost_version_dot }}/binaries/boost_${{ matrix.build_boost_version }}-msvc-${{ matrix.build_msvc_version_dot }}-32.exe", "D:\a\boostorg\boost_${{ matrix.build_boost_version }}-msvc-${{ matrix.build_msvc_version_dot }}-32.exe")
+          .\boost_${{ matrix.build_boost_version }}-msvc-${{ matrix.build_msvc_version_dot }}-64.exe /SILENT /DIR=D:\a\boostorg\boost | Out-Null
+          .\boost_${{ matrix.build_boost_version }}-msvc-${{ matrix.build_msvc_version_dot }}-32.exe /SILENT /DIR=D:\a\boostorg\boost | Out-Null
+
+    - name: run builder
+      working-directory: builder\builder\bin\Release\
+      run: .\builder.exe

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -10,12 +10,12 @@ jobs:
       matrix:
         build_configuration: [Release]
         build_platform: [Any CPU]
-        build_boost_version: [1_89_0]
-        build_boost_version_dot: [1.89.0]
+        build_boost_version: [1_90_0]
+        build_boost_version_dot: [1.90.0]
         build_msvc_version_dot: [14.3, 14.2, 14.1]
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Nuget.exe
       uses: nuget/setup-nuget@v2
@@ -34,7 +34,7 @@ jobs:
       run: |
            msbuild builder.sln /m /verbosity:minimal /t:restore /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
            msbuild builder.sln /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
-      
+
     - name: boost binary download created by https://github.com/teeks99/boost-release-windows
       working-directory: .
       run: |

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         build_configuration: [Release]
         build_platform: [Any CPU]
-        build_boost_version: [1_88_0]
-        build_boost_version_dot: [1.88.0]
+        build_boost_version: [1_89_0]
+        build_boost_version_dot: [1.89.0]
         build_msvc_version_dot: [14.3, 14.2, 14.1]
     steps:
     - name: Checkout repo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
 
   - PlatformToolset: v143
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    BUILD_BOOST_VERSION: 1_88_0
-    BUILD_BOOST_VERSION_DOT: 1.88.0
+    BUILD_BOOST_VERSION: 1_89_0
+    BUILD_BOOST_VERSION_DOT: 1.89.0
     BUILD_MSVC_VERSION_DOT: 14.3
 
 configuration:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,105 @@
+version: 1.88.{build}
+
+
+environment:
+  matrix:
+
+  - PlatformToolset: v143
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    BUILD_BOOST_VERSION: 1_88_0
+    BUILD_BOOST_VERSION_DOT: 1.88.0
+    BUILD_MSVC_VERSION_DOT: 14.3
+
+configuration:
+    - Release
+    #- Debug
+
+platform:
+    - Any CPU
+
+install:
+    - if "%platform%"=="Any CPU" set archi=amd64
+    - if "%platform%"=="Any CPU" set platform_input=Any CPU
+
+
+    - if "%PlatformToolset%"=="v140" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v141" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v142" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v143" call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+
+    - cd "%APPVEYOR_BUILD_FOLDER%"\..\..
+    - mkdir boostorg
+    - cd boostorg
+    #  build from source, but fails due to runtime limitation as each build takes ~ 40min
+    #- appveyor DownloadFile https://boostorg.jfrog.io/artifactory/main/release/%BUILD_BOOST_VERSION_DOT%/source/boost_%BUILD_BOOST_VERSION%.7z
+    #- boost.bat
+
+    # Free disk space for boost zip package
+    - rmdir /q /s C:\Qt
+    - rmdir /q /s C:\Python26
+    - rmdir /q /s C:\Python26-x64
+    - rmdir /q /s C:\Python27
+    - rmdir /q /s C:\Python27-x64
+    - rmdir /q /s C:\Python33
+    - rmdir /q /s C:\Python33-x64
+    - rmdir /q /s C:\Python34
+    - rmdir /q /s C:\Python34-x64
+    - rmdir /q /s C:\Python35
+    - rmdir /q /s C:\Python35-x64
+    - rmdir /q /s C:\Python36
+    - rmdir /q /s C:\Python36-x64
+    - rmdir /q /s C:\Python37
+    - rmdir /q /s C:\Python37-x64
+    - rmdir /q /s C:\Python38
+    - rmdir /q /s C:\Python38-x64
+    - rmdir /q /s C:\Python39
+    - rmdir /q /s C:\Python39-x64
+    - rmdir /q /s C:\Python310
+    - rmdir /q /s C:\Python310-x64
+    - rmdir /q /s C:\Python311
+    - rmdir /q /s C:\Python311-x64
+    - rmdir /q /s C:\Python312
+    - rmdir /q /s C:\Python312-x64
+
+    #  complete zip, but fails due to storage limitations on appveyor (artifactory download is much faster than sourceforge)
+    - appveyor DownloadFile https://archives.boost.io/release/%BUILD_BOOST_VERSION_DOT%/binaries/boost_%BUILD_BOOST_VERSION%-bin-msvc-all-32-64.7z
+    - 7z x -y boost_%BUILD_BOOST_VERSION%-bin-msvc-all-32-64.7z > nul
+    - del /q boost_%BUILD_BOOST_VERSION%-bin-msvc-all-32-64.7z
+    - rename boost_%BUILD_BOOST_VERSION% boost
+
+
+    #- appveyor DownloadFile https://archives.boost.io/release/%BUILD_BOOST_VERSION_DOT%/binaries/boost_%BUILD_BOOST_VERSION%-msvc-%BUILD_MSVC_VERSION_DOT%-32.exe
+    #- appveyor DownloadFile https://archives.boost.io/release/%BUILD_BOOST_VERSION_DOT%/binaries/boost_%BUILD_BOOST_VERSION%-msvc-%BUILD_MSVC_VERSION_DOT%-64.exe
+    #- boost_%BUILD_BOOST_VERSION%-msvc-%BUILD_MSVC_VERSION_DOT%-64.exe /SILENT /DIR=C:\boostorg\boost
+    #- boost_%BUILD_BOOST_VERSION%-msvc-%BUILD_MSVC_VERSION_DOT%-32.exe /SILENT /DIR=C:\boostorg\boost
+
+    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\builder\builder\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\builder\packages
+    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\builder\builderTest\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\builder\packages
+
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\builder
+    - msbuild builder.sln /m /verbosity:minimal /t:restore /p:configuration="%configuration%" /p:platform="%platform_input%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild builder.sln /m /verbosity:minimal /p:configuration="%configuration%" /p:platform="%platform_input%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\builder\builder\bin\Release\
+    - call builder.exe
+
+artifacts:
+    #- path: installer\build\**\*.*
+    #  name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: #!TODO!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v143
+        configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
 
   - PlatformToolset: v143
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    BUILD_BOOST_VERSION: 1_89_0
-    BUILD_BOOST_VERSION_DOT: 1.89.0
+    BUILD_BOOST_VERSION: 1_90_0
+    BUILD_BOOST_VERSION_DOT: 1.90.0
     BUILD_MSVC_VERSION_DOT: 14.3
 
 configuration:

--- a/builder/builder/ApiKey.cs
+++ b/builder/builder/ApiKey.cs
@@ -1,0 +1,1 @@
+//nuget api key needs to be placed here

--- a/builder/builder/App.config
+++ b/builder/builder/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
     </startup>
 </configuration>

--- a/builder/builder/Config.cs
+++ b/builder/builder/Config.cs
@@ -6,7 +6,7 @@ namespace builder
     public static class Config
     {
         public static readonly Version Version = 
-            new StableVersion(1, 87, 0);
+            new StableVersion(1, 88, 0);
 
         public static readonly List[] Release =
         {
@@ -40,9 +40,9 @@ namespace builder
             { "vc110", new CompilerInfo("Visual Studio 2012 Update 4") },
             { "vc120", new CompilerInfo("Visual Studio 2013 Update 5") },
             { "vc140", new CompilerInfo("Visual Studio 2015 Update 3") },
-            { "vc141", new CompilerInfo("Visual Studio 2017 15.9.67") },
-            { "vc142", new CompilerInfo("Visual Studio 2019 16.11.41") },
-            { "vc143", new CompilerInfo("Visual Studio 2022 17.11.5") },
+            { "vc141", new CompilerInfo("Visual Studio 2017 15.9.70") },
+            { "vc142", new CompilerInfo("Visual Studio 2019 16.11.44") },
+            { "vc143", new CompilerInfo("Visual Studio 2022 17.13.0") },
         };
 
         public static int CompilerNumber(string key)

--- a/builder/builder/Config.cs
+++ b/builder/builder/Config.cs
@@ -6,7 +6,7 @@ namespace builder
     public static class Config
     {
         public static readonly Version Version = 
-            new StableVersion(1, 89, 0);
+            new StableVersion(1, 90, 0);
 
         public static readonly List[] Release =
         {

--- a/builder/builder/Config.cs
+++ b/builder/builder/Config.cs
@@ -6,7 +6,7 @@ namespace builder
     public static class Config
     {
         public static readonly Version Version = 
-            new StableVersion(1, 88, 0);
+            new StableVersion(1, 89, 0);
 
         public static readonly List[] Release =
         {

--- a/builder/builder/Nuspec.cs
+++ b/builder/builder/Nuspec.cs
@@ -86,7 +86,7 @@ namespace builder
             nuspec.CreateDocument().Save(nuspecFile);
             Process.Start(
                 new ProcessStartInfo(
-                    @"..\..\..\packages\NuGet.CommandLine.6.13.2\tools\nuget.exe", 
+                    @"..\..\..\packages\NuGet.CommandLine.6.14.0\tools\nuget.exe", 
                     "pack " + nuspecFile)
                 {
                     UseShellExecute = false,
@@ -96,7 +96,7 @@ namespace builder
             {
 /*                 var p = Process.Start(
                   new ProcessStartInfo(
-                      @"..\..\..\packages\NuGet.CommandLine.6.13.2\tools\nuget.exe",
+                      @"..\..\..\packages\NuGet.CommandLine.6.14.0\tools\nuget.exe",
                       $"push {nupkgFile} -Source https://api.nuget.org/v3/index.json -ApiKey {ApiKey.Value}")
                   {
                       UseShellExecute = false,

--- a/builder/builder/Nuspec.cs
+++ b/builder/builder/Nuspec.cs
@@ -63,20 +63,21 @@ namespace builder
                         N("version", version.ToString()),
                         N("authors", Config.Authors),
                         N("owners", Config.Owners),
-                        N("licenseUrl", "https://github.com/sergey-shandar/getboost/blob/master/LICENSE"),
+                        N("license", Xml.A("type", "expression")).Append("BSL-1.0"),
                         N("projectUrl", "https://github.com/sergey-shandar/getboost"),
                         N("requireLicenseAcceptance", "false"),
                         N("description", description),
                         N("dependencies").Append(
+                        N("group", Xml.A("targetFramework", "native")).Append(
                             dependencyList.Select(
-                                d => 
+                                d =>
                                     N(
                                         "dependency",
                                         Xml.A("id", d.Id),
                                         Xml.A("version", d.Version)
                                     )
                             )
-                        ),
+                        )),
                         N("tags", string.Join(" ", tags))
                     ),
                     N("files").Append(fileList.Select(f => f.N))
@@ -85,7 +86,7 @@ namespace builder
             nuspec.CreateDocument().Save(nuspecFile);
             Process.Start(
                 new ProcessStartInfo(
-                    @"..\..\..\packages\NuGet.CommandLine.6.9.1\tools\nuget.exe", 
+                    @"..\..\..\packages\NuGet.CommandLine.6.13.2\tools\nuget.exe", 
                     "pack " + nuspecFile)
                 {
                     UseShellExecute = false,
@@ -93,9 +94,9 @@ namespace builder
             var nupkgFile = id + "." + version + ".nupkg";
             Console.WriteLine("uploading: " + nupkgFile);
             {
-                var p = Process.Start(
+/*                 var p = Process.Start(
                   new ProcessStartInfo(
-                      @"..\..\..\packages\NuGet.CommandLine.6.9.1\tools\nuget.exe",
+                      @"..\..\..\packages\NuGet.CommandLine.6.13.2\tools\nuget.exe",
                       $"push {nupkgFile} -Source https://api.nuget.org/v3/index.json -ApiKey {ApiKey.Value}")
                   {
                       UseShellExecute = false,
@@ -104,14 +105,14 @@ namespace builder
                 if (p.ExitCode != 0) {
                     Environment.Exit(p.ExitCode);
                 }
-            }
+ */            }
         }
 
         public static void Create(
             string nuspecId,
             string packageId,
             Version version,
-            string description, 
+            string description,
             IEnumerable<Targets.ItemDefinitionGroup> itemDefinitionGroupList,
             IEnumerable<File> fileList,
             IEnumerable<CompilationUnit> compilationUnitList,

--- a/builder/builder/builder.csproj
+++ b/builder/builder/builder.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>builder</RootNamespace>
     <AssemblyName>builder</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/builder/builder/packages.config
+++ b/builder/builder/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Framework.G1" version="1.0.13.0" targetFramework="net45" userInstalled="true" />
-  <package id="NuGet.CommandLine" version="6.13.2" targetFramework="net481" userInstalled="true" developmentDependency="true" />
+  <package id="NuGet.CommandLine" version="6.14.0" targetFramework="net481" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/builder/builder/packages.config
+++ b/builder/builder/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Framework.G1" version="1.0.13.0" targetFramework="net45" userInstalled="true" />
-  <package id="NuGet.CommandLine" version="6.9.1" targetFramework="net48" userInstalled="true" developmentDependency="true" />
+  <package id="NuGet.CommandLine" version="6.13.2" targetFramework="net481" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/builder/builderTest/builderTest.csproj
+++ b/builder/builderTest/builderTest.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>builderTest</RootNamespace>
     <AssemblyName>builderTest</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -40,7 +40,16 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Framework.G1.1.0.13.0\lib\portable-net45+sl50+win+wp80+MonoAndroid10+MonoTouch10\Framework.G1.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.Composition.Registration" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/builder/builderTest/packages.config
+++ b/builder/builderTest/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Framework.G1" version="1.0.13.0" targetFramework="net451" />
+  <package id="NuGet.CommandLine" version="6.13.2" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/builder/builderTest/packages.config
+++ b/builder/builderTest/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Framework.G1" version="1.0.13.0" targetFramework="net451" />
-  <package id="NuGet.CommandLine" version="6.13.2" targetFramework="net48" developmentDependency="true" />
+  <package id="NuGet.CommandLine" version="6.14.0" targetFramework="net48" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- github action as starting point (https://github.com/chcg/getboost/actions/runs/3256560986)
- add initial appveyor.yml CI config (https://ci.appveyor.com/project/chcg/getboost/builds/44506728)
- added dependabot action
- running from a CI job there is an issue with pushing the nuget packages as the apikey parameter is not available in that environment
- consider fixing: 

> WARNING: NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.
, see https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
`<license type="expression">BSL-1.0</license>` seems to be a replacement
 
@sergey-shandar  Is that something you are interested in? Most likely the gh actions or the appveyor config could be extended to upload the resulting nuget packages to github and/or nuget package repo. 

Should the readme be updated that the versions boost binaries used are not build on your own but taken from boost (e.g. https://archives.boost.io/release/1.88.0/binaries/) and build via https://github.com/teeks99/boost-release-windows.

